### PR TITLE
[codex] add Gemma 4 multimodal prompt support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smart_prompt (0.3.7)
+    smart_prompt (0.4.3)
       json (~> 2.19.4)
       numo-narray (~> 0.9.2.1)
       retriable (~> 3.1.2)

--- a/README.cn.md
+++ b/README.cn.md
@@ -75,6 +75,14 @@ llms:
     adapter: openai
     url: http://localhost:11434/
     default_model: deepseek-r1
+  gemma4_local:
+    adapter: openai
+    url: http://localhost:8000/v1
+    api_key: dummy
+    default_model: gemma-4-12B-it
+    temperature: 1.0
+    top_p: 0.95
+    top_k: 64
   deepseek:
     adapter: openai
     url: https://api.deepseek.com
@@ -89,6 +97,10 @@ models:
   deepseekv3.2:
     use: SiliconFlow
     model: Pro/deepseek-ai/DeepSeek-V3.2
+  gemma4/12b:
+    use: gemma4_local
+    model: gemma-4-12B-it
+    max_tokens: 1024
 
 # 默认设置
 default_llm: SiliconFlow
@@ -167,6 +179,26 @@ engine.call_worker_by_stream(:streaming_chat, {
   message: "给我讲个故事"
 }) do |chunk, bytesize|
   print chunk.dig("choices", 0, "delta", "content")
+end
+```
+
+### Gemma 4 12B 多模态
+
+Gemma 4 12B 可以通过 LiteRT-LM、LM Studio、Ollama、llama.cpp 等 OpenAI 兼容本地服务接入。SmartPrompt 会把图片放在文本前、音频放在文本后，以匹配 Gemma 4 的多模态最佳实践。
+
+```ruby
+SmartPrompt.define_worker :gemma_multimodal_assistant do
+  use_model "gemma4/12b"
+  thinking params.fetch(:thinking, true)
+  sys_msg("你是一个严谨的本地多模态助手。", params)
+
+  image(params[:image], token_budget: params[:token_budget] || 280) if params[:image]
+  video(params[:video], fps: 1, max_seconds: 60) if params[:video]
+  audio(params[:audio]) if params[:audio]
+  prompt(params[:message])
+
+  request_options(response_format: { type: "json_object" }) if params[:json]
+  send_msg
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ llms:
     adapter: openai
     url: http://localhost:11434/
     default_model: deepseek-r1
+  gemma4_local:
+    adapter: openai
+    url: http://localhost:8000/v1
+    api_key: dummy
+    default_model: gemma-4-12B-it
+    temperature: 1.0
+    top_p: 0.95
+    top_k: 64
   deepseek:
     adapter: openai
     url: https://api.deepseek.com
@@ -89,6 +97,10 @@ models:
   deepseekv3.2:
     use: SiliconFlow
     model: Pro/deepseek-ai/DeepSeek-V3.2
+  gemma4/12b:
+    use: gemma4_local
+    model: gemma-4-12B-it
+    max_tokens: 1024
 
 # Default settings
 default_llm: SiliconFlow
@@ -167,6 +179,26 @@ engine.call_worker_by_stream(:streaming_chat, {
   message: "Tell me a story"
 }) do |chunk, bytesize|
   print chunk.dig("choices", 0, "delta", "content")
+end
+```
+
+### Gemma 4 12B Multimodal
+
+Gemma 4 12B can be connected through OpenAI-compatible local servers such as LiteRT-LM, LM Studio, Ollama, or llama.cpp. SmartPrompt places images before text and audio after text to match Gemma 4 multimodal best practices.
+
+```ruby
+SmartPrompt.define_worker :gemma_multimodal_assistant do
+  use_model "gemma4/12b"
+  thinking params.fetch(:thinking, true)
+  sys_msg("You are a precise local multimodal assistant.", params)
+
+  image(params[:image], token_budget: params[:token_budget] || 280) if params[:image]
+  video(params[:video], fps: 1, max_seconds: 60) if params[:video]
+  audio(params[:audio]) if params[:audio]
+  prompt(params[:message])
+
+  request_options(response_format: { type: "json_object" }) if params[:json]
+  send_msg
 end
 ```
 

--- a/lib/smart_prompt/conversation.rb
+++ b/lib/smart_prompt/conversation.rb
@@ -5,6 +5,18 @@ require "numo/narray"
 module SmartPrompt
   class Conversation
     include APIHandler
+    MODEL_REQUEST_OPTION_KEYS = %w[
+      max_tokens
+      max_completion_tokens
+      top_p
+      top_k
+      response_format
+      tool_choice
+      parallel_tool_calls
+      seed
+      stop
+    ].freeze
+
     attr_reader :messages, :last_response, :config_file
     attr_reader :last_call_id
 
@@ -21,6 +33,9 @@ module SmartPrompt
       @current_adapter = engine.current_adapter
       @last_response = nil
       @tools = tools
+      @request_options = {}
+      @pending_content_parts = []
+      @thinking_enabled = nil
     end
 
     def use(llm_name)
@@ -43,6 +58,7 @@ module SmartPrompt
 
       use(llm_name)
       model(configured_model_name)
+      merge_model_request_options(model_config)
       self
     end
 
@@ -52,6 +68,20 @@ module SmartPrompt
 
     def temperature(temperature)
       @temperature = temperature
+    end
+
+    def request_options(options = {})
+      @request_options.merge!(options || {})
+      self
+    end
+
+    def thinking(enabled = true)
+      @thinking_enabled = enabled
+      if @sys_msg
+        @sys_msg = thinking_system_message(@sys_msg)
+        refresh_system_message(@sys_msg)
+      end
+      self
     end
 
     def history_messages
@@ -71,23 +101,43 @@ module SmartPrompt
         SmartPrompt.logger.info "Use template #{template_name}"
         raise "Template #{template_name} not found" unless @templates.key?(template_name)
         content = @templates[template_name].render(params)
-        add_message({ role: "user", content: content }, with_history)
+        add_user_content(content, with_history)
         self
       else
-        add_message({ role: "user", content: template_name }, with_history)
+        add_user_content(template_name, with_history)
         self
       end
     end
 
     def sys_msg(message, params)
-      @sys_msg = message
-      add_message({ role: "system", content: message }, params[:with_history])
+      @sys_msg = thinking_system_message(message)
+      add_message({ role: "system", content: @sys_msg }, params[:with_history])
+      self
+    end
+
+    def multimodal_prompt(parts, with_history: false)
+      add_message({ role: "user", content: normalize_content_parts(parts) }, with_history)
+      self
+    end
+
+    def image(source, token_budget: nil, **metadata)
+      @pending_content_parts << media_part("image", source, token_budget: token_budget, **metadata)
+      self
+    end
+
+    def audio(source, **metadata)
+      @pending_content_parts << media_part("audio", source, **metadata)
+      self
+    end
+
+    def video(source, fps: nil, max_seconds: nil, **metadata)
+      @pending_content_parts << media_part("video", source, fps: fps, max_seconds: max_seconds, **metadata)
       self
     end
 
     def send_msg_once
       raise "No LLM selected" if @current_llm.nil?
-      @last_response = @current_llm.send_request(@messages, @model_name, @temperature)
+      @last_response = send_llm_request(@messages, nil)
       @messages = []
       @messages << { role: "system", content: @sys_msg }
       @last_response
@@ -97,9 +147,9 @@ module SmartPrompt
       Retriable.retriable(RETRY_OPTIONS) do
         raise ConfigurationError, "No LLM selected" if @current_llm.nil?
         if params[:with_history]
-          @last_response = @current_llm.send_request(history_messages, @model_name, @temperature, @tools, nil)
+          @last_response = send_llm_request(history_messages, nil)
         else
-          @last_response = @current_llm.send_request(@messages, @model_name, @temperature, @tools, nil)
+          @last_response = send_llm_request(@messages, nil)
         end
         if @last_response == ""
           @last_response = @current_llm.last_response
@@ -116,9 +166,9 @@ module SmartPrompt
       Retriable.retriable(RETRY_OPTIONS) do
         raise ConfigurationError, "No LLM selected" if @current_llm.nil?
         if params[:with_history]
-          @current_llm.send_request(history_messages, @model_name, @temperature, @tools, proc)
+          send_llm_request(history_messages, proc)
         else
-          @current_llm.send_request(@messages, @model_name, @temperature, @tools, proc)
+          send_llm_request(@messages, proc)
         end
         @messages = []
         @messages << { role: "system", content: @sys_msg }
@@ -151,6 +201,80 @@ module SmartPrompt
         @messages << { role: "system", content: @sys_msg }
         normalize(@last_response, length)
       end
+    end
+
+    private
+
+    def send_llm_request(messages, proc)
+      parameters = @current_llm.method(:send_request).parameters
+      if parameters.length >= 6
+        @current_llm.send_request(messages, @model_name, @temperature, @tools, proc, @request_options)
+      else
+        @current_llm.send_request(messages, @model_name, @temperature, @tools, proc)
+      end
+    end
+
+    def merge_model_request_options(model_config)
+      explicit_options = model_config["request_options"] || model_config[:request_options] || {}
+      @request_options.merge!(explicit_options)
+      MODEL_REQUEST_OPTION_KEYS.each do |key|
+        value = model_config[key] || model_config[key.to_sym]
+        @request_options[key.to_sym] = value unless value.nil?
+      end
+    end
+
+    def add_user_content(content, with_history)
+      if @pending_content_parts.empty?
+        add_message({ role: "user", content: content }, with_history)
+      else
+        add_message({ role: "user", content: multimodal_content(content) }, with_history)
+        @pending_content_parts = []
+      end
+    end
+
+    def multimodal_content(text)
+      parts = @pending_content_parts
+      images_and_videos = parts.select { |part| ["image", "video"].include?(part[:type] || part["type"]) }
+      audio_parts = parts.select { |part| (part[:type] || part["type"]) == "audio" }
+      other_parts = parts - images_and_videos - audio_parts
+      normalize_content_parts(images_and_videos + other_parts + [{ type: "text", text: text.to_s }] + audio_parts)
+    end
+
+    def normalize_content_parts(parts)
+      parts.map do |part|
+        normalized = part.transform_keys(&:to_s)
+        normalized["text"] = normalized.delete("content") if normalized["type"] == "text" && normalized.key?("content")
+        normalized
+      end
+    end
+
+    def media_part(type, source, **metadata)
+      part = { type: type }
+      case type
+      when "image"
+        part[:url] = source
+      when "audio"
+        part[:audio] = source
+      when "video"
+        part[:video] = source
+      end
+      metadata.each do |key, value|
+        part[key] = value unless value.nil?
+      end
+      part
+    end
+
+    def thinking_system_message(message)
+      message = message.to_s.sub(/\A<\|think\|>\n?/, "")
+      return message if @thinking_enabled == false
+      return message unless @thinking_enabled == true
+
+      "<|think|>\n#{message}"
+    end
+
+    def refresh_system_message(message)
+      system_message = @messages.find { |item| (item[:role] || item["role"]) == "system" }
+      system_message[:content] = message if system_message
     end
   end
 end

--- a/lib/smart_prompt/engine.rb
+++ b/lib/smart_prompt/engine.rb
@@ -123,15 +123,12 @@ module SmartPrompt
         if result.class == String
           recive_message = {
             "role": "assistant",
-            "content": result,
+            "content": sanitize_history_content(result),
           }
         elsif result.class == Array
           recive_message = nil
         else
-          recive_message = {
-            "role": result.dig("choices", 0, "message", "role"),
-            "content": result.dig("choices", 0, "message", "content").to_s + result.dig("choices", 0, "message", "tool_calls").to_s,
-          }
+          recive_message = assistant_history_message(result)
         end
         worker.conversation.add_message(recive_message) if recive_message
         SmartPrompt.logger.info "Worker result is: #{result}"
@@ -174,6 +171,23 @@ module SmartPrompt
 
     def clear_history_messages
       @history_messages = []
+    end
+
+    private
+
+    def assistant_history_message(result)
+      message = result.dig("choices", 0, "message") || {}
+      history_message = {
+        "role": message["role"] || "assistant",
+        "content": sanitize_history_content(message["content"].to_s),
+      }
+      tool_calls = message["tool_calls"]
+      history_message["tool_calls"] = tool_calls if tool_calls && !tool_calls.empty?
+      history_message
+    end
+
+    def sanitize_history_content(content)
+      content.to_s.gsub(/<\|channel\>thought\n.*?<channel\|>/m, "")
     end
   end
 end

--- a/lib/smart_prompt/openai_adapter.rb
+++ b/lib/smart_prompt/openai_adapter.rb
@@ -31,7 +31,19 @@ module SmartPrompt
       end
     end
 
-    def send_request(messages, model = nil, temperature = 0.7, tools = nil, proc = nil)
+    REQUEST_PARAMETER_KEYS = %w[
+      max_tokens
+      max_completion_tokens
+      top_p
+      top_k
+      response_format
+      tool_choice
+      parallel_tool_calls
+      seed
+      stop
+    ].freeze
+
+    def send_request(messages, model = nil, temperature = 0.7, tools = nil, proc = nil, request_options = {})
       SmartPrompt.logger.info "OpenAIAdapter: Sending request to OpenAI"
       temperature = 0.7 if temperature == nil
       if model
@@ -46,6 +58,8 @@ module SmartPrompt
           messages: messages,
           temperature: @config["temperature"] || temperature,
         }
+        parameters.merge!(configured_request_parameters)
+        parameters.merge!(request_options || {})
         if proc
           parameters[:stream] = proc
         end
@@ -98,6 +112,16 @@ module SmartPrompt
         SmartPrompt.logger.info "Successful send a message"
       end
       return response.dig("data", 0, "embedding")
+    end
+
+    private
+
+    def configured_request_parameters
+      REQUEST_PARAMETER_KEYS.each_with_object({}) do |key, parameters|
+        next unless @config.key?(key)
+
+        parameters[key.to_sym] = @config[key]
+      end
     end
   end
 end

--- a/lib/smart_prompt/version.rb
+++ b/lib/smart_prompt/version.rb
@@ -1,3 +1,3 @@
 module SmartPrompt
-  VERSION = "0.4.1"
+  VERSION = "0.4.3"
 end

--- a/test/conversation_gemma_test.rb
+++ b/test/conversation_gemma_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "smart_prompt"
+
+class ConversationGemmaTest < Minitest::Test
+  class FakeEngine
+    attr_reader :adapters, :llms, :models, :templates, :current_adapter, :history_messages
+
+    def initialize(adapter)
+      @adapters = {}
+      @llms = { "gemma" => adapter }
+      @models = { "gemma4/12b" => { "use" => "gemma", "model" => "gemma-4-12B-it" } }
+      @templates = {}
+      @current_adapter = nil
+      @history_messages = []
+    end
+  end
+
+  class CapturingAdapter
+    attr_reader :messages, :request_options
+
+    def send_request(messages, _model = nil, _temperature = 0.7, _tools = nil, _proc = nil, request_options = {})
+      @messages = messages
+      @request_options = request_options
+      "ok"
+    end
+  end
+
+  def setup
+    @adapter = CapturingAdapter.new
+    @engine = FakeEngine.new(@adapter)
+  end
+
+  def test_multimodal_prompt_orders_image_text_audio_for_gemma
+    conversation = SmartPrompt::Conversation.new(@engine)
+
+    conversation.use_model("gemma4/12b")
+    conversation.image("file:///tmp/chart.png", token_budget: 560)
+    conversation.audio("file:///tmp/audio.wav")
+    conversation.prompt("Summarize the image and audio.")
+    conversation.send_msg
+
+    content = @adapter.messages.last[:content]
+    assert_equal ["image", "text", "audio"], content.map { |part| part["type"] }
+    assert_equal 560, content.first["token_budget"]
+    assert_equal "Summarize the image and audio.", content[1]["text"]
+  end
+
+  def test_thinking_prepends_gemma_control_token_to_system_prompt
+    conversation = SmartPrompt::Conversation.new(@engine)
+
+    conversation.thinking
+    conversation.sys_msg("Think carefully.", { with_history: false })
+
+    assert_equal "<|think|>\nThink carefully.", conversation.messages.first[:content]
+  end
+
+  def test_request_options_are_passed_to_six_argument_adapters
+    conversation = SmartPrompt::Conversation.new(@engine)
+
+    conversation.use("gemma")
+    conversation.request_options(response_format: { type: "json_object" })
+    conversation.prompt("Return JSON.")
+    conversation.send_msg
+
+    assert_equal({ response_format: { type: "json_object" } }, @adapter.request_options)
+  end
+end

--- a/test/openai_adapter_test.rb
+++ b/test/openai_adapter_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "smart_prompt"
+
+class OpenAIAdapterTest < Minitest::Test
+  class FakeClient
+    attr_reader :parameters
+
+    def chat(parameters:)
+      @parameters = parameters
+      {
+        "choices" => [
+          {
+            "message" => {
+              "content" => "ok",
+            },
+          },
+        ],
+      }
+    end
+  end
+
+  def test_send_request_passes_configured_generation_parameters
+    client = FakeClient.new
+    adapter = SmartPrompt::OpenAIAdapter.allocate
+    adapter.instance_variable_set(:@client, client)
+    adapter.instance_variable_set(:@config, {
+      "model" => "gemma-4-12B-it",
+      "top_p" => 0.95,
+      "top_k" => 64,
+      "max_tokens" => 512,
+    })
+
+    result = adapter.send_request([{ role: "user", content: "hello" }])
+
+    assert_equal "ok", result
+    assert_equal "gemma-4-12B-it", client.parameters[:model]
+    assert_equal 0.95, client.parameters[:top_p]
+    assert_equal 64, client.parameters[:top_k]
+    assert_equal 512, client.parameters[:max_tokens]
+  end
+
+  def test_send_request_allows_worker_request_options_to_override_config
+    client = FakeClient.new
+    adapter = SmartPrompt::OpenAIAdapter.allocate
+    adapter.instance_variable_set(:@client, client)
+    adapter.instance_variable_set(:@config, {
+      "model" => "gemma-4-12B-it",
+      "top_p" => 0.95,
+    })
+
+    adapter.send_request(
+      [{ role: "user", content: "hello" }],
+      nil,
+      0.7,
+      nil,
+      nil,
+      top_p: 0.8,
+      response_format: { type: "json_object" },
+    )
+
+    assert_equal 0.8, client.parameters[:top_p]
+    assert_equal({ type: "json_object" }, client.parameters[:response_format])
+  end
+end


### PR DESCRIPTION
## What changed

- Adds Gemma-oriented request parameter support for OpenAI-compatible adapters, including `top_p`, `top_k`, `max_tokens`, `response_format`, and related options.
- Adds Conversation DSL helpers for Gemma-style multimodal prompts: `image`, `audio`, `video`, `multimodal_prompt`, `thinking`, and `request_options`.
- Preserves structured `tool_calls` in assistant history and strips Gemma thought-channel content before writing history.
- Documents local Gemma 4 12B configuration and a multimodal worker example in English and Chinese READMEs.
- Adds focused tests for multimodal message construction and OpenAI adapter parameter passthrough.

## Why

Gemma 4 12B is useful as a local multimodal and agentic model, but SmartPrompt previously treated prompts mainly as text chat messages and only passed a small fixed set of OpenAI-compatible request fields. These changes let SmartPrompt route Gemma-specific local serving options and build multimodal message payloads without changing existing text worker usage.

## Validation

- `ruby -c lib/smart_prompt/conversation.rb`
- `ruby -c lib/smart_prompt/openai_adapter.rb`
- `ruby -c lib/smart_prompt/engine.rb`
- `ruby -c test/conversation_gemma_test.rb`
- `ruby -c test/openai_adapter_test.rb`
- Manual smoke test for Gemma-style `image/text/audio` ordering, `<|think|>` system control, and model alias request options.
- Manual smoke test for OpenAI adapter parameter passthrough and worker-level override.

Full minitest execution is currently blocked because the bundle does not include `minitest/autorun`.