### PR TITLE
add Anthropic API support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+.codex
+*.gem
+/vendor/

--- a/lib/smart_prompt/anthropic_adapter.rb
+++ b/lib/smart_prompt/anthropic_adapter.rb
@@ -239,16 +239,60 @@ module SmartPrompt
     end
 
     def extract_content(response)
-      response.fetch("content", []).map do |block|
+      text_parts = []
+      tool_calls = []
+
+      response.fetch("content", []).each do |block|
         case block["type"]
         when "text"
-          block["text"].to_s
+          text_parts << block["text"].to_s
         when "tool_use"
-          block.to_s
+          tool_calls << openai_tool_call(block)
         else
-          block.to_s
+          text_parts << block.to_s
         end
-      end.join
+      end
+
+      content = text_parts.join
+      return content if tool_calls.empty?
+
+      openai_response(response, content, tool_calls)
+    end
+
+    def openai_response(response, content, tool_calls)
+      {
+        "id" => response["id"],
+        "object" => "chat.completion",
+        "created" => Time.now.to_i,
+        "model" => response["model"],
+        "choices" => [{
+          "index" => 0,
+          "message" => {
+            "role" => "assistant",
+            "content" => content,
+            "tool_calls" => tool_calls,
+          },
+          "finish_reason" => openai_finish_reason(response["stop_reason"]),
+        }],
+        "usage" => response["usage"],
+      }
+    end
+
+    def openai_tool_call(block)
+      {
+        "id" => block["id"],
+        "type" => "function",
+        "function" => {
+          "name" => block["name"],
+          "arguments" => JSON.generate(block["input"] || {}),
+        },
+      }
+    end
+
+    def openai_finish_reason(stop_reason)
+      return "tool_calls" if stop_reason == "tool_use"
+
+      stop_reason
     end
   end
 end

--- a/test/anthropic_adapter_test.rb
+++ b/test/anthropic_adapter_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "smart_prompt"
+
+class AnthropicAdapterTest < Minitest::Test
+  def setup
+    @adapter = SmartPrompt::AnthropicAdapter.allocate
+  end
+
+  def test_extract_content_returns_string_for_text_only_response
+    response = {
+      "content" => [
+        { "type" => "text", "text" => "Hello" },
+        { "type" => "text", "text" => " world" },
+      ],
+    }
+
+    assert_equal "Hello world", @adapter.send(:extract_content, response)
+  end
+
+  def test_extract_content_preserves_tool_use_as_openai_compatible_tool_calls
+    response = {
+      "id" => "msg_123",
+      "model" => "claude-3-5-sonnet-latest",
+      "stop_reason" => "tool_use",
+      "usage" => { "input_tokens" => 10, "output_tokens" => 20 },
+      "content" => [
+        { "type" => "text", "text" => "I will check that." },
+        {
+          "type" => "tool_use",
+          "id" => "toolu_123",
+          "name" => "lookup",
+          "input" => { "query" => "weather" },
+        },
+      ],
+    }
+
+    result = @adapter.send(:extract_content, response)
+    message = result.dig("choices", 0, "message")
+    tool_call = message.fetch("tool_calls").first
+
+    assert_equal "chat.completion", result["object"]
+    assert_equal "assistant", message["role"]
+    assert_equal "I will check that.", message["content"]
+    assert_equal "tool_calls", result.dig("choices", 0, "finish_reason")
+    assert_equal "toolu_123", tool_call["id"]
+    assert_equal "function", tool_call["type"]
+    assert_equal "lookup", tool_call.dig("function", "name")
+    assert_equal({ "query" => "weather" }, JSON.parse(tool_call.dig("function", "arguments")))
+  end
+end


### PR DESCRIPTION
## What changed

- Adds Gemma-oriented request parameter support for OpenAI-compatible adapters.
- Adds Conversation DSL helpers for Gemma-style multimodal prompts: `image`, `audio`, `video`, `multimodal_prompt`, `thinking`, and `request_options`.
- Preserves structured tool calls in assistant history and Anthropic adapter responses.
- Documents local Gemma 4 12B configuration and multimodal worker examples.
- Bumps SmartPrompt version to `0.4.3` and ignores local artifacts.

## Validation

- `ruby -c lib/smart_prompt/conversation.rb`
- `ruby -c lib/smart_prompt/openai_adapter.rb`
- `ruby -c lib/smart_prompt/engine.rb`
- `ruby -c lib/smart_prompt/anthropic_adapter.rb`
- `ruby -c test/conversation_gemma_test.rb`
- `ruby -c test/openai_adapter_test.rb`
- `ruby -c test/anthropic_adapter_test.rb`
- Manual smoke tests for Gemma-style multimodal message ordering and OpenAI parameter passthrough.

Full minitest execution is currently blocked because the bundle does not include `minitest/autorun`.